### PR TITLE
making path to pipeline git repository an environment variable 

### DIFF
--- a/trunk/bin/comparecatalogs.py
+++ b/trunk/bin/comparecatalogs.py
@@ -4,8 +4,10 @@ import lsc
 import os
 import argparse
 
-gitdir = os.path.join(lsc.util.workdirectory, 'github/lcogtsnpipe/trunk/')
+gitdir = os.path.join(os.getenv('LCOSNPIPE', os.path.join(lsc.util.workdirectory, 'github/lcogtsnpipe/')), 'trunk')
 catdir = os.path.join(gitdir, 'src/lsc/standard/cat/')
+
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-F', '--force', action='store_true', help="try to download catalog even if we've tried before")


### PR DESCRIPTION
with a default to the previous version if no variable exists to make the script more flexible. This should be transparent to LCO