### PR TITLE
Fix targname get standards

### DIFF
--- a/trunk/src/lsc/myloopdef.py
+++ b/trunk/src/lsc/myloopdef.py
@@ -1648,6 +1648,7 @@ def get_list(epoch=None, _telescope='all', _filter='', _bad='', _name='', _id=''
 
 def get_standards(epoch, name, filters):
     epochs = process_epoch(epoch)
+    flexible_name = name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%')
     query = '''SELECT DISTINCT std.filepath, std.filename, std.objname, std.filter,
                std.wcs, std.psf, std.psfmag, std.zcat, std.mag, std.abscat, std.lastunpacked
                FROM
@@ -1674,8 +1675,8 @@ def get_standards(epoch, name, filters):
                AND std.quality = 127
                AND obj.dayobs >= {start}
                AND obj.dayobs <= {end}
-               AND targobj.name = "{name}"
-               '''.format(start=epochs[0], end=epochs[-1], name=name)
+               AND targobj.name LIKE "{name}"
+               '''.format(start=epochs[0], end=epochs[-1], name=flexible_name)
     if filters:
         query += 'AND (obj.filter="' + '" OR obj.filter="'.join(lsc.sites.filterst[filters]) + '")'
     print 'Searching for corresponding standard fields. This may take a minute...'


### PR DESCRIPTION
When get_list is called, it eventually searched for objects ```LIKE _name.lower().replace('at20', 'at20%').replace('sn20', 'sn20%').replace(' ', '%')```. However, when get_standards is called and tries to match standards with object observations, it uses ```=name``` where name is exactly as specified by the user. This leads to the object being found by get_list but no standards found, making this issue hard to diagnose. This change replaces the definition of name in get_standards with the more flexible definition used by get_list.