### PR TITLE
Fix calibratemag no stds

### DIFF
--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         lista = f.read().splitlines()
     if not lista:
         sys.exit('calibratemag.py: ' + args.imglist + ' is empty')
-    if args.stage == 'local' and not args.exzp is None:
+    if args.stage == 'local' and args.exzp is not None:
         sys.exit('To run the local stage you must pass -e. It may be that no standards were found by myloopdef.get_standards')
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:

--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         lista = f.read().splitlines()
     if not lista:
         sys.exit('calibratemag.py: ' + args.imglist + ' is empty')
-    if args.stage == 'local' and args.exzp is not None:
+    if args.stage == 'local' and args.exzp is None:
         sys.exit('To run the local stage you must pass -e. It may be that no standards were found by myloopdef.get_standards')
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:

--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -121,7 +121,8 @@ if __name__ == "__main__":
         lista = f.read().splitlines()
     if not lista:
         sys.exit('calibratemag.py: ' + args.imglist + ' is empty')
-
+    if args.stage == 'local' and not args.exzp is None:
+        sys.exit('To run the local stage you must pass -e. It may be that no standards were found by myloopdef.get_standards')
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:
             refcat = Table.read(args.catalog, format='ascii', fill_values=[('9999.000', '0')])

--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     if not lista:
         sys.exit('calibratemag.py: ' + args.imglist + ' is empty')
     if args.stage == 'local' and args.exzp is None:
-        sys.exit('To run the local stage you must pass -e. It may be that no standards were found by myloopdef.get_standards')
+        sys.exit('No file with external zeropoints was passed to calibratemag.py. It may be that no standards were found by myloopdef.get_standards')
     if args.stage in ['abscat', 'local'] and args.catalog is not None:
         try:
             refcat = Table.read(args.catalog, format='ascii', fill_values=[('9999.000', '0')])


### PR DESCRIPTION
calibratemag silently failed when no standards were found. This adds an error message. Its not clear to me which branch this should go on, I'm putting it on the export pipe branch since presumable LCO doesn't encounter this issue since standards are automatically ingested.