### PR TITLE
also add images to photlco when ingesting with LCOGTingest.py

### DIFF
--- a/trunk/bin/LCOGTingest.py
+++ b/trunk/bin/LCOGTingest.py
@@ -298,11 +298,15 @@ if __name__ == "__main__":
 
     print 'Total number of frames:', len(frames)
 
+    fullpaths = []
     for frame in frames:
         if '.tar.gz' not in frame['filename']:
             filepath, filename = download_frame(frame, args.force_dl)
             dbdict = db_ingest(filepath, filename, args.force_db)
-            if '-en' in filename and '-e00.fits' in filename:
+            if '-en' not in filename:
+                fullpaths.append(filepath + filename)
+            elif '-e00.fits' in filename:
                 fits2png(filepath + filename, args.force_tn)
         else:
             record_floyds_tar_link(authtoken, frame, args.force_gl)
+    lsc.mysqldef.ingestredu(fullpaths)  # ingest new data into photlco

--- a/trunk/bin/LCOGTingest.py
+++ b/trunk/bin/LCOGTingest.py
@@ -205,7 +205,8 @@ def db_ingest(filepath, filename, force=False):
                     dbdict[dbcol] = hdr[hdrkey]
         if hdr['TELESCOP'] not in telescopeids:
             logger.info('{} not recognized. Adding to telescopes table.'.format(hdr['TELESCOP']))
-            lsc.mysqldef.insert_values(conn, 'telescopes', {'name': hdr['TELESCOP']})
+            lsc.mysqldef.insert_values(conn, 'telescopes', {'name': hdr['TELESCOP'],
+                                                            'shortname': hdr['SITEID']})
             telescopes = lsc.mysqldef.query(['select id, name from telescopes'], conn)
             telescopeids = {tel['name']: tel['id'] for tel in telescopes}
         dbdict['telescopeid'] = telescopeids[hdr['TELESCOP']]


### PR DESCRIPTION
The GSP uses ingestall.py to ingest its data on a cronjob. Data can also be ingested semi-manually with LCOGTingest.py, but then they are only added to photlcoraw and not photlco. This aligns both ingestion scripts to ingest into both tables.

Note, however, that outside users cannot use LCOGTingest.py to get proprietary data without credentials for archive.lco.global, but they can, for example, ingest standard star images this way.