### PR TITLE
Fix calibratemag to mask observations without standards

### DIFF
--- a/trunk/bin/calibratemag.py
+++ b/trunk/bin/calibratemag.py
@@ -151,7 +151,8 @@ if __name__ == "__main__":
             lista2 = f.read().splitlines()
         standards = get_image_data(lista2)
         standards = standards.group_by(['dayobs', 'shortname', 'instrument', 'filter', 'zcol1', 'zcol2'])
-        targets[['zcol1', 'z1', 'dz1', 'c1', 'dc1', 'zcol2', 'z2', 'dz2', 'c2', 'dc2']].mask = True
+        for icol in ['zcol1', 'z1', 'dz1', 'c1', 'dc1', 'zcol2', 'z2', 'dz2', 'c2', 'dc2']:
+            targets[icol].mask = True
         for group in standards.groups:
             matches_in_targets = ((targets['dayobs'] == group['dayobs'][0]) & (targets['shortname'] == group['shortname'][0])
                                    & (targets['instrument'] == group['instrument'][0]) & (targets['filter'] == group['filter'][0]))


### PR DESCRIPTION
The current version, does not mask columns correctly. When these columns have not been populated (likely you are creating the local sequence catalog for the first time), then these columns are empty (which is equivalent to being masked). However, if you create the catalog after completing the calibration of the SN using the local sequence, the nights without coincident standard star observations will be included in calculating the local sequence. Attached are figures of what the interactive plots look like before and after the fix (before has many more observations on it).

Before:
![Screen Shot 2020-04-16 at 4 10 41 PM](https://user-images.githubusercontent.com/2522639/81224202-32501280-8f9c-11ea-84a2-ab4d9188af9e.png)

After:
![Screen Shot 2020-05-06 at 10 53 32 AM](https://user-images.githubusercontent.com/2522639/81224241-4267f200-8f9c-11ea-8c67-b24b06a62252.png)
